### PR TITLE
Guyana country code correction

### DIFF
--- a/constants/countryCodes.ts
+++ b/constants/countryCodes.ts
@@ -2877,7 +2877,7 @@ export const countryCodes: CountryItem[] = [
             "tr": "Guyana",
             "hu": "Guyana"
         },
-        "dial_code": "+595",
+        "dial_code": "+592",
         "code": "GY",
         "flag": "🇬🇾"
     },


### PR DESCRIPTION
Guyana country code is +592 instead of +595